### PR TITLE
Sort users in teams alphabetically

### DIFF
--- a/src/api/teams/helpers/get-team.js
+++ b/src/api/teams/helpers/get-team.js
@@ -8,6 +8,11 @@ async function getTeam(db, teamId) {
           from: 'users',
           localField: 'users',
           foreignField: '_id',
+          pipeline: [
+            {
+              $sort: { name: 1 }
+            }
+          ],
           as: 'users'
         }
       },


### PR DESCRIPTION
Sort users in teams alphabetically in one place on the API rather than multiple places in the UI