### PR TITLE
Ignore certain dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "wednesday"
+    ignore:
+      - dependency-name: "node-fetch"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@octokit/core"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@octokit/plugin-paginate-graphql"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint-plugin-n"
+        update-types: ["version-update:semver-major"]
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
- Bump Node to latest DEFRA available LTS - v20.11.1
- Add simple `dependabot`
- Update dependencies
- Lock some dependencies to minor and patch only