### PR TITLE
352519 user delete part II

### DIFF
--- a/jest-mongodb-config.js
+++ b/jest-mongodb-config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  mongodbMemoryServerOptions: {
+    binary: {
+      skipMD5: true
+    },
+    autoStart: false,
+    instance: {
+      dbName: 'cdp-user-service-backend'
+    }
+  },
+  mongoURLEnvName: 'MONGO_URI'
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   resetModules: true,
   clearMocks: true,
   silent: true,
+  preset: '@shelf/jest-mongodb',
   testMatch: ['**/src/**/*.test.js'],
   reporters: ['default', ['github-actions', { silent: false }], 'summary'],
   collectCoverageFrom: ['src/**/*.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@babel/core": "7.24.6",
         "@babel/node": "7.24.6",
         "@babel/preset-env": "7.24.6",
+        "@shelf/jest-mongodb": "4.3.2",
         "babel-jest": "29.7.0",
         "babel-loader": "9.1.3",
         "eslint": "^8.57.0",
@@ -3607,6 +3608,40 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@shelf/jest-mongodb": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@shelf/jest-mongodb/-/jest-mongodb-4.3.2.tgz",
+      "integrity": "sha512-LL7NBaT04sJspoOZXqw3HGLw0+XnZNlIV72x2ymzyuloqIKXwgUl8eL1XKDUh4Ud8dUBRMrOngCQBcHKjWnrHQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4.3.4",
+        "mongodb-memory-server": "9.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "jest-environment-node": "28.x || 29.x",
+        "mongodb": "3.x.x || 4.x || 5.x || 6.x"
+      }
+    },
+    "node_modules/@shelf/jest-mongodb/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -4334,6 +4369,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/async-mutex": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.4.1.tgz",
+      "integrity": "sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -4361,6 +4405,12 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
       "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g=="
+    },
+    "node_modules/b4a": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.6.tgz",
+      "integrity": "sha512-5Tk1HLk6b6ctmjIkAcU/Ujv/1WqiDl0F0JdRCR80VsOcUlHcu7pWeWRlOqQLHfDEsVx9YH/aif5AG4ehoCtTmg==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4757,6 +4807,13 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "node_modules/bare-events": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.4.2.tgz",
+      "integrity": "sha512-qMKFd2qG/36aA4GwvKq8MxnPgCQAmBWmSyLWsJcbn8v03wvIPQ/hG1Ms8bPzndZxMDoHpxez5VOS+gC9Yi24/Q==",
+      "dev": true,
+      "optional": true
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -4899,6 +4956,15 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -6459,6 +6525,12 @@
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6582,6 +6654,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -7167,6 +7259,25 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "devOptional": true,
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ip-address/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "devOptional": true
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.4",
@@ -9321,6 +9432,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "devOptional": true
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -9832,6 +9949,215 @@
         "whatwg-url": "^13.0.0"
       }
     },
+    "node_modules/mongodb-memory-server": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-9.2.0.tgz",
+      "integrity": "sha512-w/usKdYtby5EALERxmA0+et+D0brP0InH3a26shNDgGefXA61hgl6U0P3IfwqZlEGRZdkbZig3n57AHZgDiwvg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "mongodb-memory-server-core": "9.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-9.2.0.tgz",
+      "integrity": "sha512-9SWZEy+dGj5Fvm5RY/mtqHZKS64o4heDwReD4SsfR7+uNgtYo+JN41kPCcJeIH3aJf04j25i5Dia2s52KmsMPA==",
+      "dev": true,
+      "dependencies": {
+        "async-mutex": "^0.4.0",
+        "camelcase": "^6.3.0",
+        "debug": "^4.3.4",
+        "find-cache-dir": "^3.3.2",
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^7.0.4",
+        "mongodb": "^5.9.1",
+        "new-find-package-json": "^2.0.0",
+        "semver": "^7.6.0",
+        "tar-stream": "^3.1.7",
+        "tslib": "^2.6.2",
+        "yauzl": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/@types/whatwg-url": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
+      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/bson": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.1.tgz",
+      "integrity": "sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.20.1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
+      "dev": true,
+      "dependencies": {
+        "bson": "^5.5.0",
+        "mongodb-connection-string-url": "^2.6.0",
+        "socks": "^2.7.1"
+      },
+      "engines": {
+        "node": ">=14.20.1"
+      },
+      "optionalDependencies": {
+        "@mongodb-js/saslprep": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.0.0",
+        "kerberos": "^1.0.0 || ^2.0.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
+        "snappy": "^7.2.2"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/mongodb-connection-string-url": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
+      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongodb-memory-server-core/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -9867,6 +10193,18 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/new-find-package-json": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/new-find-package-json/-/new-find-package-json-2.0.0.tgz",
+      "integrity": "sha512-lDcBsjBSMlj3LXH2v/FW3txlh2pYTjmbOXPYJD93HI5EwuLzI11tdHSIpUMmfq/IOsldj4Ps8M8flhm+pCK4Ew==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      }
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
@@ -10462,6 +10800,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
@@ -10894,6 +11238,12 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/queue-tick": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
+      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
+      "dev": true
     },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
@@ -11485,6 +11835,30 @@
         "node": ">=6"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "devOptional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
+      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "devOptional": true,
+      "dependencies": {
+        "ip-address": "^9.0.5",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.0.1.tgz",
@@ -11603,6 +11977,20 @@
       "engines": {
         "node": ">=4",
         "npm": ">=6"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.18.0.tgz",
+      "integrity": "sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==",
+      "dev": true,
+      "dependencies": {
+        "fast-fifo": "^1.3.2",
+        "queue-tick": "^1.0.1",
+        "text-decoder": "^1.1.0"
+      },
+      "optionalDependencies": {
+        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -11798,6 +12186,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/tar-stream": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
     "node_modules/terser": {
       "version": "5.31.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
@@ -11931,6 +12330,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.0.tgz",
+      "integrity": "sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==",
+      "dev": true,
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/text-table": {
@@ -12626,6 +13034,19 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.1.3.tgz",
+      "integrity": "sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==",
+      "dev": true,
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@babel/core": "7.24.6",
     "@babel/node": "7.24.6",
     "@babel/preset-env": "7.24.6",
+    "@shelf/jest-mongodb": "4.3.2",
     "babel-jest": "29.7.0",
     "babel-loader": "9.1.3",
     "eslint": "^8.57.0",

--- a/src/__mocks__/pino.js
+++ b/src/__mocks__/pino.js
@@ -1,0 +1,38 @@
+import originalPino from 'pino'
+
+// Mock logger
+const mockPino = {
+  levels: {
+    labels: {
+      10: 'trace',
+      20: 'debug',
+      30: 'info',
+      40: 'warn',
+      50: 'error',
+      60: 'fatal'
+    },
+    values: {
+      trace: 10,
+      debug: 20,
+      info: 30,
+      warn: 40,
+      error: 50,
+      fatal: 60
+    }
+  },
+  fatal: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+  info: jest.fn(),
+  debug: jest.fn(),
+  trace: jest.fn(),
+  silent: jest.fn()
+}
+mockPino.child = () => mockPino
+
+const mockPinoFunc = () => mockPino
+mockPinoFunc.stdSerializers = originalPino.stdSerializers
+
+jest.doMock('pino', () => mockPinoFunc)
+
+module.exports = require('pino')

--- a/src/__mocks__/pino.js
+++ b/src/__mocks__/pino.js
@@ -1,6 +1,5 @@
-import originalPino from 'pino'
+import pino from 'pino'
 
-// Mock logger
 const mockPino = {
   levels: {
     labels: {
@@ -20,19 +19,19 @@ const mockPino = {
       fatal: 60
     }
   },
-  fatal: jest.fn(),
-  error: jest.fn(),
-  warn: jest.fn(),
-  info: jest.fn(),
-  debug: jest.fn(),
   trace: jest.fn(),
+  debug: jest.fn(),
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  fatal: jest.fn(),
   silent: jest.fn()
 }
 mockPino.child = () => mockPino
 
 const mockPinoFunc = () => mockPino
-mockPinoFunc.stdSerializers = originalPino.stdSerializers
+mockPinoFunc.stdSerializers = pino.stdSerializers
 
 jest.doMock('pino', () => mockPinoFunc)
 
-module.exports = require('pino')
+export default () => pino

--- a/src/api/teams/controllers/remove-user-from-team.js
+++ b/src/api/teams/controllers/remove-user-from-team.js
@@ -27,13 +27,7 @@ const removeUserFromTeamController = {
       throw Boom.notFound('User or Team not found')
     }
 
-    const team = await removeUserFromTeam(
-      request.msGraph,
-      request.mongoClient,
-      request.db,
-      userId,
-      teamId
-    )
+    const team = await removeUserFromTeam(request, userId, teamId)
     return h.response({ message: 'success', team }).code(200)
   }
 }

--- a/src/api/teams/helpers/remove-user-from-aad-group.js
+++ b/src/api/teams/helpers/remove-user-from-aad-group.js
@@ -1,0 +1,30 @@
+/**
+ * User service could be out of sync with AAD.
+ * To avoid aborting the parent operation guard against group and/or user no longer existing in AAD.
+ *
+ * @param msGraph
+ * @param logger
+ * @param teamId
+ * @param userId
+ * @returns {Promise<void>}
+ */
+async function removeUserFromAadGroup(msGraph, logger, teamId, userId) {
+  try {
+    const teamMembersResult = await msGraph
+      .api(`/groups/${teamId}/members`)
+      .get()
+    const teamMembers = teamMembersResult?.value?.map((member) => member.id)
+
+    if (teamMembers.includes(userId)) {
+      await msGraph.api(`/groups/${teamId}/members/${userId}/$ref`).delete()
+      logger.info(`User: ${userId} removed from AAD teamId: ${teamId}`)
+    }
+  } catch (error) {
+    logger.error(
+      { error },
+      `User: ${userId} removal from AAD group:${teamId} failed due to: ${error.message}`
+    )
+  }
+}
+
+export { removeUserFromAadGroup }

--- a/src/api/teams/helpers/remove-user-from-team.js
+++ b/src/api/teams/helpers/remove-user-from-team.js
@@ -1,27 +1,35 @@
 import { getTeam } from '~/src/api/teams/helpers/mongo/get-team'
+import { removeUserFromAadGroup } from '~/src/api/teams/helpers/remove-user-from-aad-group'
+import { transactionOptions } from '~/src/constants/transaction-options'
 
-async function removeUserFromTeam(msGraph, mongoClient, db, userId, teamId) {
+async function removeUserFromTeam(request, userId, teamId) {
+  const { db, mongoClient, msGraph, logger } = request
+
   const session = mongoClient.startSession()
-  session.startTransaction()
+
   try {
-    await msGraph.api(`/groups/${teamId}/members/${userId}/$ref`).delete()
+    await session.withTransaction(async () => {
+      await removeUserFromAadGroup(msGraph, logger, teamId, userId)
 
-    await db
-      .collection('users')
-      .updateOne({ _id: userId }, { $pull: { teams: teamId } })
+      await db
+        .collection('users')
+        .updateOne({ _id: userId }, { $pull: { teams: teamId } })
 
-    await db.collection('teams').findOneAndUpdate(
-      { _id: teamId },
-      {
-        $pull: { users: userId },
-        $set: { updatedAt: new Date() }
-      }
-    )
+      await db.collection('teams').findOneAndUpdate(
+        { _id: teamId },
+        {
+          $pull: { users: userId },
+          $set: { updatedAt: new Date() }
+        }
+      )
 
-    await session.commitTransaction()
-    return await getTeam(db, teamId)
+      return await getTeam(db, teamId)
+    }, transactionOptions)
   } catch (error) {
-    await session.abortTransaction()
+    logger.error(
+      { error },
+      `User removal from team aborted due to: ${error.message}`
+    )
     throw error
   } finally {
     await session.endSession()

--- a/src/api/users/controllers/delete-user.js
+++ b/src/api/users/controllers/delete-user.js
@@ -1,0 +1,36 @@
+import Joi from 'joi'
+import Boom from '@hapi/boom'
+
+import { config } from '~/src/config'
+import { deleteUser } from '~/src/api/users/helpers/delete-user'
+
+const deleteUserController = {
+  options: {
+    validate: {
+      params: Joi.object({
+        userId: Joi.string().uuid().required()
+      })
+    },
+    auth: {
+      strategy: 'azure-oidc',
+      access: {
+        scope: [config.get('oidcAdminGroupId')]
+      }
+    }
+  },
+  handler: async (request, h) => {
+    try {
+      await deleteUser(request, request.params?.userId)
+
+      return h.response({ message: 'success' }).code(200)
+    } catch (error) {
+      if (error.isBoom) {
+        return error
+      }
+
+      return Boom.notImplemented('Something went wrong. User not deleted!')
+    }
+  }
+}
+
+export { deleteUserController }

--- a/src/api/users/controllers/delete-user.test.js
+++ b/src/api/users/controllers/delete-user.test.js
@@ -1,0 +1,184 @@
+import { config } from '~/src/config'
+import { createServer } from '~/src/api/server'
+import { Client } from '@microsoft/microsoft-graph-client'
+
+jest.mock('@microsoft/microsoft-graph-client')
+jest.mock('@azure/identity')
+
+describe('/users/{userId}', () => {
+  const mockUser = {
+    _id: '2fdc6295-b3e5-409e-846a-2ec237f20977',
+    name: 'Tetsuo Shima',
+    email: 'tetsuo.shima@email.com',
+    github: 'TetsuoShima',
+    defraVpnId: '1234556789',
+    defraAwsId: 'abcde-123456',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+  const mockUserInATeam = {
+    _id: 'be675e78-a02a-433a-b7f5-a0786730a283',
+    name: 'Akira',
+    email: 'akira@email.com',
+    github: 'Akira',
+    defraVpnId: '546456456',
+    defraAwsId: '45645-dfgddgd',
+    teams: ['aea8bc8e-0dec-4fd7-a1f5-c69ead3f39ab'],
+    createdAt: new Date(),
+    updatedAt: new Date()
+  }
+  const mockTeam = {
+    _id: 'aea8bc8e-0dec-4fd7-a1f5-c69ead3f39ab',
+    name: 'A-team',
+    description: 'The A-team',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    users: ['be675e78-a02a-433a-b7f5-a0786730a283'],
+    github: 'a-team'
+  }
+  let server
+  let mockMsGraph
+
+  beforeAll(async () => {
+    // Mock MsGraph client
+    mockMsGraph = {
+      api: jest.fn().mockReturnThis(),
+      get: jest.fn(),
+      delete: jest.fn()
+    }
+    Client.initWithMiddleware = () => mockMsGraph
+
+    server = await createServer()
+    await server.initialize()
+  })
+
+  beforeEach(async () => {
+    await server.db.collection('users').insertMany([mockUser, mockUserInATeam])
+    await server.db.collection('teams').insertOne(mockTeam)
+  })
+
+  afterEach(async () => {
+    await server.db.collection('users').drop()
+    await server.db.collection('teams').drop()
+  })
+
+  afterAll(async () => {
+    await server.mongoClient.close()
+    await server.stop({ timeout: 0 })
+  })
+
+  const callDeleteUser = async (url) =>
+    await server.inject({
+      method: 'DELETE',
+      url,
+      auth: {
+        strategy: 'azure-oidc',
+        credentials: {
+          scope: [config.get('oidcAdminGroupId')]
+        }
+      }
+    })
+
+  test('Should error when non uuid passed as userId param', async () => {
+    const result = await callDeleteUser('/users/not-a-uuid')
+
+    expect(result.statusMessage).toEqual('Bad Request')
+    expect(result.statusCode).toEqual(400)
+  })
+
+  test('Should error when user uuid does not exist in the db', async () => {
+    const result = await callDeleteUser(
+      '/users/8469dcf7-846d-43fd-899a-9850bc43298b'
+    )
+
+    expect(server.logger.error).toHaveBeenCalledWith(
+      { error: Error('User not found') },
+      'User deletion aborted due to: User not found'
+    )
+    expect(result.statusMessage).toEqual('Not Found')
+    expect(result.statusCode).toEqual(404)
+  })
+
+  describe('When a user is not in any teams', () => {
+    test('Should delete a user from DB', async () => {
+      const result = await callDeleteUser(`/users/${mockUser._id}`)
+
+      expect(server.logger.info).toHaveBeenCalledWith('User deleted from CDP')
+      expect(result.statusMessage).toEqual('OK')
+      expect(result.statusCode).toEqual(200)
+    })
+  })
+
+  describe('When a user is in a team', () => {
+    test('Should remove user from the AAD team and delete the user from DB', async () => {
+      mockMsGraph.get.mockReturnValue({
+        value: [{ id: mockUserInATeam._id }]
+      })
+      mockMsGraph.delete.mockResolvedValue()
+
+      const result = await callDeleteUser(`/users/${mockUserInATeam._id}`)
+
+      // Call to get members of a group
+      expect(mockMsGraph.api).toHaveBeenNthCalledWith(
+        1,
+        `/groups/${mockTeam._id}/members`
+      )
+      expect(mockMsGraph.get).toHaveBeenCalledTimes(1)
+
+      // Call to remove user from a group
+      expect(mockMsGraph.api).toHaveBeenNthCalledWith(
+        2,
+        `/groups/${mockTeam._id}/members/${mockUserInATeam._id}/$ref`
+      )
+      expect(mockMsGraph.delete).toHaveBeenCalledTimes(1)
+      expect(server.logger.info).toHaveBeenNthCalledWith(
+        1,
+        `User: ${mockUserInATeam._id} removed from AAD teamId: ${mockTeam._id}`
+      )
+
+      // User removed from the DB
+      expect(server.logger.info).toHaveBeenNthCalledWith(
+        2,
+        `User removed from CDP ${mockTeam.name} team`
+      )
+      expect(server.logger.info).toHaveBeenNthCalledWith(
+        3,
+        'User deleted from CDP'
+      )
+
+      expect(result.statusMessage).toEqual('OK')
+      expect(result.statusCode).toEqual(200)
+    })
+  })
+
+  describe('When DB and AAD are out of sync', () => {
+    test('Should complete DB user removal from team and DB user deletion', async () => {
+      mockMsGraph.get.mockReturnValue({ value: [] })
+
+      const result = await callDeleteUser(`/users/${mockUserInATeam._id}`)
+
+      // Call to get members of a group
+      expect(mockMsGraph.api).toHaveBeenNthCalledWith(
+        1,
+        `/groups/${mockTeam._id}/members`
+      )
+      expect(mockMsGraph.get).toHaveBeenCalledTimes(1)
+
+      // No call to remove user from a group
+      expect(mockMsGraph.delete).not.toHaveBeenCalled()
+
+      // User removed from the DB
+      expect(server.logger.info).toHaveBeenNthCalledWith(
+        1,
+        `User removed from CDP ${mockTeam.name} team`
+      )
+      expect(server.logger.info).toHaveBeenNthCalledWith(
+        2,
+        'User deleted from CDP'
+      )
+
+      expect(result.statusMessage).toEqual('OK')
+      expect(result.statusCode).toEqual(200)
+    })
+  })
+})

--- a/src/api/users/controllers/index.js
+++ b/src/api/users/controllers/index.js
@@ -1,6 +1,7 @@
 import { getUserController } from '~/src/api/users/controllers/get-user'
 import { getUsersController } from '~/src/api/users/controllers/get-users'
 import { createUserController } from '~/src/api/users/controllers/create-user'
+import { deleteUserController } from '~/src/api/users/controllers/delete-user'
 import { updateUserController } from '~/src/api/users/controllers/update-user'
 import { getAadUsersController } from '~/src/api/users/controllers/get-aad-users'
 import { getGitHubUsersController } from '~/src/api/users/controllers/get-github-users'
@@ -9,6 +10,7 @@ export {
   getUserController,
   getUsersController,
   createUserController,
+  deleteUserController,
   updateUserController,
   getAadUsersController,
   getGitHubUsersController

--- a/src/api/users/helpers/delete-user.js
+++ b/src/api/users/helpers/delete-user.js
@@ -1,0 +1,69 @@
+import Boom from '@hapi/boom'
+import { isNull } from 'lodash'
+
+import { getUser } from '~/src/api/users/helpers/get-user'
+import { removeUserFromAadGroup } from '~/src/api/teams/helpers/remove-user-from-aad-group'
+import { transactionOptions } from '~/src/constants/transaction-options'
+
+function throwUserNotFound(user) {
+  if (isNull(user)) {
+    throw Boom.notFound('User not found')
+  }
+}
+
+function updateTeamUsers(db, msGraph, logger) {
+  const teamsCollection = db.collection('teams')
+
+  return async (teamId, userId) => {
+    await removeUserFromAadGroup(msGraph, logger, teamId, userId)
+
+    const team = await teamsCollection.findOneAndUpdate(
+      { _id: teamId },
+      {
+        $pull: { users: userId },
+        $set: { updatedAt: new Date() }
+      }
+    )
+
+    logger.info(`User removed from CDP ${team.name} team`)
+  }
+}
+
+async function deleteUser(request, userId) {
+  const { db, mongoClient, msGraph, logger } = request
+
+  const session = mongoClient.startSession()
+
+  try {
+    await session.withTransaction(async () => {
+      const user = await getUser(db, userId)
+      throwUserNotFound(user)
+
+      const removeUserFromTeam = updateTeamUsers(db, msGraph, logger)
+      const cdpTeams = user?.teams ?? []
+
+      if (cdpTeams.length) {
+        const removeFromTeams = cdpTeams.map((team) =>
+          removeUserFromTeam(team.teamId, user.userId)
+        )
+        await Promise.all(removeFromTeams)
+      }
+
+      const usersCollection = db.collection('users')
+      const { deletedCount = 0 } = await usersCollection.deleteOne({
+        _id: userId
+      })
+
+      if (deletedCount === 1) {
+        logger.info('User deleted from CDP')
+      }
+    }, transactionOptions)
+  } catch (error) {
+    logger.error({ error }, `User deletion aborted due to: ${error.message}`)
+    throw error
+  } finally {
+    await session.endSession()
+  }
+}
+
+export { deleteUser }

--- a/src/api/users/index.js
+++ b/src/api/users/index.js
@@ -1,5 +1,6 @@
 import {
   createUserController,
+  deleteUserController,
   getUserController,
   getUsersController,
   updateUserController,
@@ -31,6 +32,11 @@ const users = {
           method: 'PATCH',
           path: '/users/{userId}',
           ...updateUserController
+        },
+        {
+          method: 'DELETE',
+          path: '/users/{userId}',
+          ...deleteUserController
         },
         {
           method: 'GET',

--- a/src/constants/transaction-options.js
+++ b/src/constants/transaction-options.js
@@ -1,0 +1,7 @@
+const transactionOptions = {
+  readPreference: 'primary',
+  readConcern: { level: 'local' },
+  writeConcern: { w: 'majority' }
+}
+
+export { transactionOptions }

--- a/src/helpers/mongodb.js
+++ b/src/helpers/mongodb.js
@@ -24,8 +24,12 @@ const mongoPlugin = {
 
     server.logger.info(`mongodb connected to ${databaseName}`)
 
+    server.decorate('server', 'mongoClient', mongoClient)
     server.decorate('request', 'mongoClient', mongoClient)
+
+    server.decorate('server', 'db', db)
     server.decorate('request', 'db', db)
+
     server.decorate('request', 'locker', locker)
 
     await createIndexes(db)


### PR DESCRIPTION
## DELETE: /users/{userId}

The new `DELETE: /users/{userId}` endpoint will:
- Remove user from teams they belong to in AAD 
  - Note this now will silently fail and log. This is due to AAD and DB potentially being out of sync 
- Remove users from teams they belong to in the User service backend Teams collection
- Remove the user from the User service backend User collection

## PATCH: /teams/{teamId}/remove/{userId}

Fix bug in `PATCH: /teams/{teamId}/remove/{userId}` endpoint, where transaction would fail if user details in AAD were out of sync with the User service DB. E.g they have been deleted in AAD or don't exist on the team.

## Testing functionality
This Pr adds some super useful things for testing which ultimately allow us to test apps at the controller level, in unit tests, with a Jest provided in memory mongo and mocking of things like, `logging`, `msGraph`, `db` and `mongoClient`.

> Note I'm not chasing 90% coverage, just tests of value and tooling to help with that

- In memory mongo for tests only - https://jestjs.io/docs/mongodb
- Mocked `pino`
- Mocked `msGraph`

More info can be found in the delete user test 

### Main
> current coverage

<img width="793" alt="Screenshot 2024-06-28 at 15 10 46" src="https://github.com/DEFRA/cdp-user-service-backend/assets/2305016/2dbaa1d6-7844-4152-baf6-8d19bf9de533">


### This PR

<img width="816" alt="Screenshot 2024-06-28 at 15 08 40" src="https://github.com/DEFRA/cdp-user-service-backend/assets/2305016/9ac62444-48d4-4a13-ab16-4e0a4edace9c">




## Associated PR's

https://github.com/DEFRA/cdp-portal-frontend/pull/452