### PR TITLE
Bump undici dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "mongo-locks": "3.0.2",
         "mongodb": "6.7.0",
         "pino": "9.1.0",
-        "undici": "6.18.2"
+        "undici": "6.19.2"
       },
       "devDependencies": {
         "@babel/cli": "7.24.6",
@@ -12560,9 +12560,9 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "6.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.18.2.tgz",
-      "integrity": "sha512-o/MQLTwRm9IVhOqhZ0NQ9oXax1ygPjw6Vs+Vq/4QRjbOAC3B1GCHy7TYxxbExKlb7bzDRzt9vBWU6BDz0RFfYg==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.19.2.tgz",
+      "integrity": "sha512-JfjKqIauur3Q6biAtHJ564e3bWa8VvT+7cSiOJHFbX4Erv6CLGDpg8z+Fmg/1OI/47RA+GI2QZaF48SSaLvyBA==",
       "engines": {
         "node": ">=18.17"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "mongo-locks": "3.0.2",
     "mongodb": "6.7.0",
     "pino": "9.1.0",
-    "undici": "6.18.2"
+    "undici": "6.19.2"
   },
   "devDependencies": {
     "@babel/cli": "7.24.6",

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -99,7 +99,7 @@ const config = convict({
     doc: 'MsGraph api endpoint',
     format: String,
     env: 'AZURE_CLIENT_BASE_URL',
-    default: ''
+    default: 'http://localhost:3939/msgraph/'
   },
   oidcWellKnownConfigurationUrl: {
     doc: 'OIDC .well-known configuration URL',

--- a/src/helpers/ms-graph.js
+++ b/src/helpers/ms-graph.js
@@ -43,23 +43,16 @@ const msGraphPlugin = {
         }
       )
 
-      const clientOptions = {
+      const msGraph = Client.initWithMiddleware({
         debugLogging: true,
         authProvider,
+        baseUrl: azureClientBaseUrl,
         ...(proxy && {
           fetchOptions: {
             dispatcher: proxy.proxyAgent
           }
         })
-      }
-
-      if (azureClientBaseUrl !== '') {
-        server.logger.debug(
-          `Overriding azure client base url with ${azureClientBaseUrl}`
-        )
-        clientOptions.baseUrl = azureClientBaseUrl
-      }
-      const msGraph = Client.initWithMiddleware(clientOptions)
+      })
 
       server.decorate('request', 'msGraph', msGraph)
     }


### PR DESCRIPTION
- Bump dependency back to what it was. This wasn't the issue
- Always set the msGraph client `clientOptions.baseUrl` 
- Set the `AZURE_CLIENT_BASE_URL` config property to the local development value `http://localhost:3939/msgraph/`
- Add the `AZURE_CLIENT_BASE_URL` env in https://github.com/DEFRA/cdp-app-config/pull/497

This does mean we are explicitly setting this, so it won't be as easy to override by accident in the apps default config. But it also means we are no longer relying on the default they set in the lib. Which may come back to bite if they update it - Thoughts?

@chotai had some good thoughts on this:
- `https://graph.microsoft.com/` is unlikely to change and other things will break also if this changes
- Rathe than having an empty string. Its nice to be explicit when setting this value