### PR TITLE
Reworks admin check to just use a normal scope.

### DIFF
--- a/src/__fixtures__/scopes.js
+++ b/src/__fixtures__/scopes.js
@@ -40,9 +40,20 @@ const breakGlassFixture = {
   updatedAt: '2024-12-05T17:42:30.508Z'
 }
 
+const adminFixture = {
+  _id: new ObjectId('7751e606a171ebffac3cc9dd'),
+  userId: '62bb35d2-d4f2-4cf6-abd3-262d99727677',
+  value: 'admin',
+  description: 'Allows team to administer the Portal',
+  teams: ['aabe63e7-87ef-4beb-a596-c810631fc474'], // platformTeamFixture
+  createdAt: '2024-12-05T17:42:30.508Z',
+  updatedAt: '2024-12-05T17:42:30.508Z'
+}
+
 export {
   externalTestScopeFixture,
   postgresScopeFixture,
   terminalScopeFixture,
-  breakGlassFixture
+  breakGlassFixture,
+  adminFixture
 }

--- a/src/__fixtures__/teams.js
+++ b/src/__fixtures__/teams.js
@@ -9,8 +9,11 @@ const platformTeamFixture = {
   alertEmailAddresses: ['mary@mary.com'],
   createdAt: '2023-09-28T13:52:01.906Z',
   updatedAt: '2024-12-04T08:17:06.795Z',
-  users: ['62bb35d2-d4f2-4cf6-abd3-262d99727677'], // userOneFixture
-  scopes: [new ObjectId('67500e94922c4fe819dd8832')] // externalTestScopeFixture
+  users: ['62bb35d2-d4f2-4cf6-abd3-262d99727677'], // admin user
+  scopes: [
+    new ObjectId('67500e94922c4fe819dd8832'), // externalTestScopeFixture
+    new ObjectId('7751e606a171ebffac3cc9dd') // adminScopeFixture
+  ]
 }
 
 const tenantTeamFixture = {

--- a/src/__fixtures__/users.js
+++ b/src/__fixtures__/users.js
@@ -1,6 +1,6 @@
 import { ObjectId } from 'mongodb'
 
-const userOneFixture = {
+const userAdminFixture = {
   _id: '62bb35d2-d4f2-4cf6-abd3-262d99727677',
   name: 'TetsuoShima',
   email: 'tetsuo.shima@defra.onmicrosoft.com',
@@ -8,10 +8,13 @@ const userOneFixture = {
   updatedAt: '2024-12-03T12:26:28.965Z',
   github: 'TetsuoShima',
   teams: ['aabe63e7-87ef-4beb-a596-c810631fc474'], // platformTeamFixture
-  scopes: [new ObjectId('6751e606a171ebffac3cc9dd')] // breakGlassFixture
+  scopes: [
+    new ObjectId('6751e606a171ebffac3cc9dd'), // breakGlassFixture
+    new ObjectId('7751e606a171ebffac3cc9dd') // adminScopeFixture
+  ]
 }
 
-const userTwoFixture = {
+const userTenantFixture = {
   _id: 'b7606810-f0c6-4db7-b067-ba730ef706e8',
   name: 'Akira',
   email: 'akira@defra.onmicrosoft.com',
@@ -21,7 +24,7 @@ const userTwoFixture = {
   scopes: [new ObjectId('6751e5e9a171ebffac3cc9dc')] // terminalScopeFixture
 }
 
-const userThreeFixture = {
+const userPostgresFixture = {
   _id: 'ad760f75-0930-434f-8a4e-174f74723c65',
   name: 'RoboCop',
   email: 'robocop@defra.onmicrosoft.com',
@@ -31,4 +34,4 @@ const userThreeFixture = {
   scopes: [new ObjectId('6751b8bcfd2ecb117d6277de')] // postgresScopeFixture
 }
 
-export { userOneFixture, userTwoFixture, userThreeFixture }
+export { userAdminFixture, userTenantFixture, userPostgresFixture }

--- a/src/api/scopes/controllers/get-scopes-for-user.test.js
+++ b/src/api/scopes/controllers/get-scopes-for-user.test.js
@@ -8,15 +8,16 @@ import {
   tenantTeamFixture
 } from '~/src/__fixtures__/teams.js'
 import {
+  adminFixture,
   breakGlassFixture,
   externalTestScopeFixture,
   postgresScopeFixture,
   terminalScopeFixture
 } from '~/src/__fixtures__/scopes.js'
 import {
-  userOneFixture,
-  userThreeFixture,
-  userTwoFixture
+  userAdminFixture,
+  userPostgresFixture,
+  userTenantFixture
 } from '~/src/__fixtures__/users.js'
 import { deleteMany, replaceMany } from '~/test-helpers/mongo-helpers.js'
 
@@ -45,9 +46,9 @@ describe('GET:/scopes', () => {
 
   beforeEach(async () => {
     await replaceManyTestHelper('users', [
-      userOneFixture,
-      userTwoFixture,
-      userThreeFixture
+      userAdminFixture,
+      userTenantFixture,
+      userPostgresFixture
     ])
     await replaceManyTestHelper('teams', [
       platformTeamFixture,
@@ -57,7 +58,8 @@ describe('GET:/scopes', () => {
       externalTestScopeFixture,
       postgresScopeFixture,
       terminalScopeFixture,
-      breakGlassFixture
+      breakGlassFixture,
+      adminFixture
     ])
   })
 
@@ -84,7 +86,7 @@ describe('GET:/scopes', () => {
   describe('With tenant scope', () => {
     test('Should provide response with expected scopes and flags', async () => {
       const { result, statusCode, statusMessage } = await scopesEndpoint({
-        id: userOneFixture._id,
+        id: userTenantFixture._id,
         scope: [tenantTeamFixture._id]
       })
 
@@ -95,9 +97,9 @@ describe('GET:/scopes', () => {
         message: 'success',
         scopes: [
           '2a45e0cd-9f1b-4158-825d-40e561c55c55',
-          'breakGlass',
+          'terminal',
           'postgres',
-          '62bb35d2-d4f2-4cf6-abd3-262d99727677',
+          userTenantFixture._id,
           'tenant'
         ],
         scopeFlags: {
@@ -132,21 +134,22 @@ describe('GET:/scopes', () => {
   describe('With admin scope', () => {
     test('Should provide response with expected scopes and flags', async () => {
       const { result, statusCode, statusMessage } = await scopesEndpoint({
-        id: userTwoFixture._id,
+        id: userAdminFixture._id,
         scope: [platformTeamFixture._id]
       })
 
+      result.scopes.sort()
+
       expect(statusCode).toBe(200)
       expect(statusMessage).toBe('OK')
-
       expect(result).toMatchObject({
         message: 'success',
         scopes: [
-          'aabe63e7-87ef-4beb-a596-c810631fc474',
-          'terminal',
-          'externalTest',
-          'b7606810-f0c6-4db7-b067-ba730ef706e8',
-          'admin'
+          userAdminFixture._id,
+          platformTeamFixture._id,
+          'admin',
+          'breakGlass',
+          'externalTest'
         ],
         scopeFlags: {
           isAdmin: true,
@@ -174,7 +177,7 @@ describe('GET:/scopes', () => {
     test('Should provide scopes without duplicates', async () => {
       // User three and Tenant team have the same postgres scope
       const { result, statusCode, statusMessage } = await scopesEndpoint({
-        id: userThreeFixture._id,
+        id: userPostgresFixture._id,
         scope: [tenantTeamFixture._id]
       })
 

--- a/src/api/scopes/helpers/scopes-for-user.js
+++ b/src/api/scopes/helpers/scopes-for-user.js
@@ -5,7 +5,7 @@ import { isUserInATenantTeam } from '~/src/helpers/user/is-user-in-a-tenant-team
 
 async function scopesForUser(credentials, db) {
   const jwtScopes = credentials.scope
-  const adminGroupId = config.get('oidcAdminGroupId')
+  const adminScope = config.get('adminScope')
 
   const userId = credentials.id
   const user = await getUser(db, userId)
@@ -30,12 +30,9 @@ async function scopesForUser(credentials, db) {
     scopes.push(userId)
   }
 
-  const isAdmin = scopes.includes(adminGroupId)
-  if (isAdmin) {
-    scopes.push('admin')
-  }
+  const isAdmin = scopes.includes(adminScope)
 
-  const isTenant = isUserInATenantTeam(allTeamIds, scopes, adminGroupId)
+  const isTenant = !isAdmin && isUserInATenantTeam(allTeamIds, scopes)
   if (isTenant) {
     scopes.push('tenant')
   }

--- a/src/api/scopes/helpers/scopes-for-user.js
+++ b/src/api/scopes/helpers/scopes-for-user.js
@@ -1,11 +1,10 @@
-import { config } from '~/src/config/config.js'
 import { getUser } from '~/src/api/users/helpers/get-user.js'
 import { getTeams } from '~/src/api/teams/helpers/get-teams.js'
 import { isUserInATenantTeam } from '~/src/helpers/user/is-user-in-a-tenant-team.js'
 
 async function scopesForUser(credentials, db) {
   const jwtScopes = credentials.scope
-  const adminScope = config.get('adminScope')
+  const adminScope = 'admin'
 
   const userId = credentials.id
   const user = await getUser(db, userId)

--- a/src/api/teams/controllers/delete-team.test.js
+++ b/src/api/teams/controllers/delete-team.test.js
@@ -4,7 +4,10 @@ import { config } from '~/src/config/config.js'
 import { createServer } from '~/src/api/server.js'
 import { Client } from '@microsoft/microsoft-graph-client'
 import { wellKnownResponseFixture } from '~/src/__fixtures__/well-known.js'
-import { userOneFixture, userTwoFixture } from '~/src/__fixtures__/users.js'
+import {
+  userAdminFixture,
+  userTenantFixture
+} from '~/src/__fixtures__/users.js'
 import {
   platformTeamFixture,
   teamWithoutUsers,
@@ -147,11 +150,11 @@ describe('DELETE:/teams/{teamId}', () => {
 
     beforeEach(async () => {
       mockMsGraph.get.mockReturnValue({
-        value: [{ id: userOneFixture._id }]
+        value: [{ id: userAdminFixture._id }]
       })
       mockMsGraph.delete.mockResolvedValue()
 
-      await replaceOneTestHelper('users', userOneFixture)
+      await replaceOneTestHelper('users', userAdminFixture)
       await replaceOneTestHelper('teams', platformTeamFixture)
 
       deleteTeamResponse = await deleteTeamEndpoint(
@@ -174,7 +177,7 @@ describe('DELETE:/teams/{teamId}', () => {
     test('Should call AAD to remove user from a group', () => {
       expect(mockMsGraph.api).toHaveBeenNthCalledWith(
         2,
-        `/groups/${platformTeamFixture._id}/members/${userOneFixture._id}/$ref`
+        `/groups/${platformTeamFixture._id}/members/${userAdminFixture._id}/$ref`
       )
       expect(mockMsGraph.delete).toHaveBeenCalledTimes(1)
     })
@@ -201,7 +204,7 @@ describe('DELETE:/teams/{teamId}', () => {
         result: userResult,
         statusCode: userStatusCode,
         statusMessage: userStatusMessage
-      } = await server.inject(`/users/${userOneFixture._id}`)
+      } = await server.inject(`/users/${userAdminFixture._id}`)
 
       expect(userStatusCode).toBe(200)
       expect(userStatusMessage).toBe('OK')
@@ -232,7 +235,7 @@ describe('DELETE:/teams/{teamId}', () => {
     beforeEach(async () => {
       mockMsGraph.get.mockReturnValue({ value: [] })
 
-      await replaceOneTestHelper('users', userTwoFixture)
+      await replaceOneTestHelper('users', userTenantFixture)
       await replaceOneTestHelper('teams', tenantTeamFixture)
 
       deleteTeamResponse = await deleteTeamEndpoint(
@@ -278,7 +281,7 @@ describe('DELETE:/teams/{teamId}', () => {
         result: userResult,
         statusCode: userStatusCode,
         statusMessage: userStatusMessage
-      } = await server.inject(`/users/${userTwoFixture._id}`)
+      } = await server.inject(`/users/${userTenantFixture._id}`)
 
       expect(userStatusCode).toBe(200)
       expect(userStatusMessage).toBe('OK')

--- a/src/api/users/controllers/delete-user.test.js
+++ b/src/api/users/controllers/delete-user.test.js
@@ -4,7 +4,10 @@ import { Client } from '@microsoft/microsoft-graph-client'
 import { config } from '~/src/config/config.js'
 import { createServer } from '~/src/api/server.js'
 import { wellKnownResponseFixture } from '~/src/__fixtures__/well-known.js'
-import { userOneFixture, userTwoFixture } from '~/src/__fixtures__/users.js'
+import {
+  userAdminFixture,
+  userTenantFixture
+} from '~/src/__fixtures__/users.js'
 import {
   platformTeamFixture,
   tenantTeamFixture
@@ -101,11 +104,11 @@ describe('DELETE:/users/{userId}', () => {
     let deleteUserResponse
 
     beforeEach(async () => {
-      await replaceOneTestHelper('users', userOneFixture)
+      await replaceOneTestHelper('users', userAdminFixture)
       await replaceOneTestHelper('teams', tenantTeamFixture)
 
       deleteUserResponse = await deleteUserEndpoint(
-        `/users/${userOneFixture._id}`
+        `/users/${userAdminFixture._id}`
       )
     })
 
@@ -118,7 +121,7 @@ describe('DELETE:/users/{userId}', () => {
         result: userResult,
         statusCode: userStatusCode,
         statusMessage: userStatusMessage
-      } = await server.inject(`/users/${userOneFixture._id}`)
+      } = await server.inject(`/users/${userAdminFixture._id}`)
 
       expect(userStatusCode).toBe(404)
       expect(userStatusMessage).toBe('Not Found')
@@ -147,15 +150,15 @@ describe('DELETE:/users/{userId}', () => {
 
     beforeEach(async () => {
       mockMsGraph.get.mockReturnValue({
-        value: [{ id: userOneFixture._id }]
+        value: [{ id: userAdminFixture._id }]
       })
       mockMsGraph.delete.mockResolvedValue()
 
-      await replaceOneTestHelper('users', userOneFixture)
+      await replaceOneTestHelper('users', userAdminFixture)
       await replaceOneTestHelper('teams', platformTeamFixture)
 
       deleteUserResponse = await deleteUserEndpoint(
-        `/users/${userOneFixture._id}`
+        `/users/${userAdminFixture._id}`
       )
     })
 
@@ -174,7 +177,7 @@ describe('DELETE:/users/{userId}', () => {
     test('Should call AAD to remove user from a group', () => {
       expect(mockMsGraph.api).toHaveBeenNthCalledWith(
         2,
-        `/groups/${platformTeamFixture._id}/members/${userOneFixture._id}/$ref`
+        `/groups/${platformTeamFixture._id}/members/${userAdminFixture._id}/$ref`
       )
       expect(mockMsGraph.delete).toHaveBeenCalledTimes(1)
     })
@@ -184,7 +187,7 @@ describe('DELETE:/users/{userId}', () => {
         result: userResult,
         statusCode: userStatusCode,
         statusMessage: userStatusMessage
-      } = await server.inject(`/users/${userOneFixture._id}`)
+      } = await server.inject(`/users/${userAdminFixture._id}`)
 
       expect(userStatusCode).toBe(404)
       expect(userStatusMessage).toBe('Not Found')
@@ -232,11 +235,11 @@ describe('DELETE:/users/{userId}', () => {
     beforeEach(async () => {
       mockMsGraph.get.mockReturnValue({ value: [] })
 
-      await replaceOneTestHelper('users', userTwoFixture)
+      await replaceOneTestHelper('users', userTenantFixture)
       await replaceOneTestHelper('teams', tenantTeamFixture)
 
       deleteUserResponse = await deleteUserEndpoint(
-        `/users/${userTwoFixture._id}`
+        `/users/${userTenantFixture._id}`
       )
     })
 
@@ -261,7 +264,7 @@ describe('DELETE:/users/{userId}', () => {
         result: userResult,
         statusCode: userStatusCode,
         statusMessage: userStatusMessage
-      } = await server.inject(`/users/${userTwoFixture._id}`)
+      } = await server.inject(`/users/${userTenantFixture._id}`)
 
       expect(userStatusCode).toBe(404)
       expect(userStatusMessage).toBe('Not Found')
@@ -307,7 +310,7 @@ describe('DELETE:/users/{userId}', () => {
     test('Should provide expected unauthorized response', async () => {
       const { result, statusCode, statusMessage } = await server.inject({
         method: 'DELETE',
-        url: `/users/${userTwoFixture._id}`
+        url: `/users/${userTenantFixture._id}`
       })
 
       expect(statusCode).toBe(401)

--- a/src/api/users/controllers/get-user.test.js
+++ b/src/api/users/controllers/get-user.test.js
@@ -3,7 +3,7 @@ import fetchMock from 'jest-fetch-mock'
 import { config } from '~/src/config/config.js'
 import { createServer } from '~/src/api/server.js'
 import { wellKnownResponseFixture } from '~/src/__fixtures__/well-known.js'
-import { userOneFixture } from '~/src/__fixtures__/users.js'
+import { userAdminFixture } from '~/src/__fixtures__/users.js'
 import { deleteMany, replaceOne } from '~/test-helpers/mongo-helpers.js'
 
 const oidcWellKnownConfigurationUrl = config.get(
@@ -43,7 +43,7 @@ describe('GET:/users/{userId}', () => {
 
   describe('When a user is in the DB', () => {
     beforeEach(async () => {
-      await replaceOneTestHelper('users', userOneFixture)
+      await replaceOneTestHelper('users', userAdminFixture)
     })
 
     afterEach(async () => {
@@ -52,7 +52,7 @@ describe('GET:/users/{userId}', () => {
 
     test('Should provide expected response', async () => {
       const { result, statusCode, statusMessage } = await getUserEndpoint(
-        `/users/${userOneFixture._id}`
+        `/users/${userAdminFixture._id}`
       )
 
       expect(statusCode).toBe(200)

--- a/src/api/users/controllers/get-users.test.js
+++ b/src/api/users/controllers/get-users.test.js
@@ -3,7 +3,10 @@ import fetchMock from 'jest-fetch-mock'
 import { config } from '~/src/config/config.js'
 import { createServer } from '~/src/api/server.js'
 import { wellKnownResponseFixture } from '~/src/__fixtures__/well-known.js'
-import { userOneFixture, userTwoFixture } from '~/src/__fixtures__/users.js'
+import {
+  userAdminFixture,
+  userTenantFixture
+} from '~/src/__fixtures__/users.js'
 import { deleteMany, replaceMany } from '~/test-helpers/mongo-helpers.js'
 
 const oidcWellKnownConfigurationUrl = config.get(
@@ -43,7 +46,10 @@ describe('GET:/users', () => {
 
   describe('When users are in the DB', () => {
     beforeEach(async () => {
-      await replaceManyTestHelper('users', [userOneFixture, userTwoFixture])
+      await replaceManyTestHelper('users', [
+        userAdminFixture,
+        userTenantFixture
+      ])
     })
 
     afterEach(async () => {

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -164,11 +164,10 @@ const config = convict({
     env: 'OIDC_AUDIENCE',
     default: '26372ac9-d8f0-4da9-a17e-938eb3161d8e'
   },
-  oidcAdminGroupId: {
-    doc: 'OIDC Admin Group ID',
+  adminScope: {
+    doc: 'OIDC Admin Scope',
     format: String,
-    env: 'OIDC_ADMIN_GROUP_ID',
-    default: 'aabe63e7-87ef-4beb-a596-c810631fc474'
+    default: 'admin'
   },
   gitHubAppId: {
     doc: 'GitHub Api authentication App Id',

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -164,11 +164,6 @@ const config = convict({
     env: 'OIDC_AUDIENCE',
     default: '26372ac9-d8f0-4da9-a17e-938eb3161d8e'
   },
-  adminScope: {
-    doc: 'OIDC Admin Scope',
-    format: String,
-    default: 'admin'
-  },
   gitHubAppId: {
     doc: 'GitHub Api authentication App Id',
     format: String,

--- a/src/helpers/user/is-user-in-a-service-team.test.js
+++ b/src/helpers/user/is-user-in-a-service-team.test.js
@@ -2,7 +2,7 @@ import { config } from '~/src/config/config.js'
 import { isUserInATenantTeam } from '~/src/helpers/user/is-user-in-a-tenant-team.js'
 
 describe('#isUserInATenantTeam', () => {
-  const adminGroupId = config.get('oidcAdminGroupId')
+  const adminGroupId = config.get('adminScope')
 
   test('With matching team id, should return true', () => {
     const teamIds = ['mockService']

--- a/src/helpers/user/is-user-in-a-service-team.test.js
+++ b/src/helpers/user/is-user-in-a-service-team.test.js
@@ -1,13 +1,10 @@
-import { config } from '~/src/config/config.js'
 import { isUserInATenantTeam } from '~/src/helpers/user/is-user-in-a-tenant-team.js'
 
 describe('#isUserInATenantTeam', () => {
-  const adminGroupId = config.get('adminScope')
-
   test('With matching team id, should return true', () => {
     const teamIds = ['mockService']
     const scopes = ['mockService']
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
+    const result = isUserInATenantTeam(teamIds, scopes)
 
     expect(result).toBe(true)
   })
@@ -15,15 +12,7 @@ describe('#isUserInATenantTeam', () => {
   test('With no matching scopes, should be false', () => {
     const teamIds = ['mockServiceOne']
     const scopes = ['mockService']
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
-
-    expect(result).toBe(false)
-  })
-
-  test('With admin teamId only, should be false', () => {
-    const teamIds = [adminGroupId]
-    const scopes = []
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
+    const result = isUserInATenantTeam(teamIds, scopes)
 
     expect(result).toBe(false)
   })
@@ -31,7 +20,7 @@ describe('#isUserInATenantTeam', () => {
   test('With multiple matching team ids, should return true', () => {
     const teamIds = ['mockService', 'mockServiceTwo']
     const scopes = ['mockServiceTwo', 'mockService']
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
+    const result = isUserInATenantTeam(teamIds, scopes)
 
     expect(result).toBe(true)
   })
@@ -39,7 +28,7 @@ describe('#isUserInATenantTeam', () => {
   test('With multiple team ids and one matching scope, should return true', () => {
     const teamIds = ['mockService', 'mockServiceThree']
     const scopes = ['mockServiceThree']
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
+    const result = isUserInATenantTeam(teamIds, scopes)
 
     expect(result).toBe(true)
   })
@@ -47,7 +36,7 @@ describe('#isUserInATenantTeam', () => {
   test('With empty team ids and scopes, should return false', () => {
     const teamIds = []
     const scopes = []
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
+    const result = isUserInATenantTeam(teamIds, scopes)
 
     expect(result).toBe(false)
   })
@@ -55,7 +44,7 @@ describe('#isUserInATenantTeam', () => {
   test('With empty team ids and non-empty scopes, should return false', () => {
     const teamIds = []
     const scopes = ['mockServiceTen']
-    const result = isUserInATenantTeam(teamIds, scopes, adminGroupId)
+    const result = isUserInATenantTeam(teamIds, scopes)
 
     expect(result).toBe(false)
   })

--- a/src/helpers/user/is-user-in-a-tenant-team.js
+++ b/src/helpers/user/is-user-in-a-tenant-team.js
@@ -2,13 +2,10 @@
  * Check if a teamId is in the provide scopes
  * @param {Array<string>} teamIds
  * @param {Array<string>} scopes
- * @param {string} adminGroupId
  * @returns {boolean}
  */
-function isUserInATenantTeam(teamIds, scopes, adminGroupId) {
-  return scopes
-    .filter((scope) => scope !== adminGroupId)
-    .some((scope) => teamIds.includes(scope))
+function isUserInATenantTeam(teamIds, scopes) {
+  return scopes.some((scope) => teamIds.includes(scope))
 }
 
 export { isUserInATenantTeam }


### PR DESCRIPTION
Before deploying we will need to create the admin scope and assign it to the platform team.