### PR TITLE
Removes use of Promise.all inside transactions.

### DIFF
--- a/src/constants/transaction-options.js
+++ b/src/constants/transaction-options.js
@@ -4,7 +4,7 @@ const { mongoOptions } = config.get('mongo')
 
 const transactionOptions = {
   ...mongoOptions,
-  readConcern: { level: 'local' },
+  readConcern: { level: 'majority' },
   writeConcern: { w: 'majority' }
 }
 

--- a/src/helpers/mongo/transactions/scope/delete-scope-transaction.js
+++ b/src/helpers/mongo/transactions/scope/delete-scope-transaction.js
@@ -20,33 +20,30 @@ async function deleteScopeTransaction({ request, scopeId }) {
 
   await mongoTransaction(async ({ db, session }) => {
     // Remove scope from teams
-    const scopeTeamsPromises = scope.teams.map((team) =>
-      removeScopeFromTeam({
+    for (const team of scope.teams) {
+      await removeScopeFromTeam({
         db,
         session,
         teamId: team.teamId,
         scopeId,
         scopeName: scope.value
       })
-    )
-    await Promise.all(scopeTeamsPromises)
+    }
 
     // Remove scope from users
-    const scopeUsersPromises = scope.users.map((user) =>
-      removeScopeFromUser({ db, session, scopeId, userId: user.userId })
-    )
-    await Promise.all(scopeUsersPromises)
+    for (const user of scope.users) {
+      await removeScopeFromUser({ db, session, scopeId, userId: user.userId })
+    }
 
     // Remove scope from members
-    const scopeMembersPromises = scope.members.map((member) =>
-      removeScopeFromUsers({
+    for (const member of scope.members) {
+      await removeScopeFromUsers({
         db,
         session,
         scopeId,
         userId: member.userId
       })
-    )
-    await Promise.all(scopeMembersPromises)
+    }
 
     // Remove any left-over scopes from users. For instance scopes assigned due to team membership
     await removeScopeFromUsers({ db, session, scopeId })

--- a/src/helpers/mongo/transactions/team/delete-team-transaction.js
+++ b/src/helpers/mongo/transactions/team/delete-team-transaction.js
@@ -20,26 +20,24 @@ async function deleteTeamTransaction({ request, teamId }) {
   await mongoTransaction(async ({ db, session }) => {
     if (team.users?.length) {
       // Remove any team scopes from user.teams
-      const removeTeamScopesFromTeamUsers = team.users.map((user) =>
-        removeTeamScopesFromUser({
+      for (const user of team.users) {
+        await removeTeamScopesFromUser({
           db,
           session,
           userId: user.userId,
           teamId
         })
-      )
-      await Promise.all(removeTeamScopesFromTeamUsers)
+      }
 
       // Remove the team from user.teams
-      const removeTeamFromUsers = team.users.map((user) =>
-        removeTeamFromUser({
+      for (const user of team.users) {
+        await removeTeamFromUser({
           db,
           session,
           userId: user.userId,
           teamId: team.teamId
         })
-      )
-      await Promise.all(removeTeamFromUsers)
+      }
     }
 
     // Remove any scopes in scope.teams or scope.members for this team


### PR DESCRIPTION
see: https://www.mongodb.com/docs/drivers/node/current/crud/transactions/

```
Avoid parallelism, such as calling the Promise.all() method. Using sessions in parallel usually leads to server errors.
```